### PR TITLE
Reconnect to database after parallel exits

### DIFF
--- a/lib/acts_as_scrubbable/tasks.rb
+++ b/lib/acts_as_scrubbable/tasks.rb
@@ -81,7 +81,7 @@ namespace :scrub do
 
       @logger.info "#{scrubbed_count} #{ar_class} objects scrubbed".blue
     end
-
+    ActiveRecord::Base.connection.verify!
 
     if ENV["SKIP_AFTERHOOK"].blank?
       @logger.info "Running after hook".red


### PR DESCRIPTION
The database connections are lost when using processes.
This is explicitly called out in parallel's documentation: https://github.com/grosser/parallel#activerecord

This is seen when using a version of `mysql2` `>= 0.4.2` currently:

```
2017-02-13 14:09:45 -0800: [INFO] - Running after hook
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error: MySQL server has gone away: SELECT `models`.* FROM `models`
/Users/astegman/.gem/ruby/2.3.1/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `_query'
/Users/astegman/.gem/ruby/2.3.1/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `block in query'
/Users/astegman/.gem/ruby/2.3.1/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `handle_interrupt'
/Users/astegman/.gem/ruby/2.3.1/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `query'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:309:in `block in execute'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_adapter.rb:484:in `block in log'
/Users/astegman/.gem/ruby/2.3.1/gems/activesupport-4.2.7.1/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:309:in `execute'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/mysql2_adapter.rb:231:in `execute'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/mysql2_adapter.rb:235:in `exec_query'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract/database_statements.rb:356:in `select'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/querying.rb:39:in `find_by_sql'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:639:in `exec_queries'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:515:in `load'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/relation.rb:243:in `to_a'
/Users/astegman/.gem/ruby/2.3.1/gems/bullet-4.14.0/lib/bullet/active_record42.rb:10:in `to_a'
/Users/astegman/.gem/ruby/2.3.1/gems/activerecord-4.2.7.1/lib/active_record/relation/delegation.rb:46:in `each'
/Users/astegman/$PROJECT/config/initializers/scrubbable.rb:31:in `block (2 levels) in <top (required)>'
/Users/astegman/.gem/ruby/2.3.1/gems/acts_as_scrubbable-0.1.1/lib/acts_as_scrubbable.rb:24:in `execute_after_hook'
```

Wild guess that it's a side effect of brianmario/mysql2#684, but I can't confirm. Definitely introduced in 0.4.3, though.