### PR TITLE
Scoped was deprecated in Rails 4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_scrubbable (0.1.2)
+    acts_as_scrubbable (0.1.3)
       activerecord (>= 4.1, < 5.1)
       activesupport (>= 4.1, < 5.1)
       faker (>= 1.4)
@@ -149,4 +149,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/lib/acts_as_scrubbable/tasks.rb
+++ b/lib/acts_as_scrubbable/tasks.rb
@@ -65,9 +65,11 @@ namespace :scrub do
       scrubbed_count = 0
 
       ActiveRecord::Base.connection_pool.with_connection do
-
-        relation = ar_class.scoped
-        relation = relation.send(:scrubbable_scope) if ar_class.respond_to?(:scrubbable_scope)
+        if ar_class.respond_to?(:scrubbable_scope)
+          relation = ar_class.send(:scrubbable_scope)
+        else
+          relation = ar_class.all
+        end
 
         relation.find_in_batches(batch_size: 1000) do |batch|
           ActiveRecord::Base.transaction do


### PR DESCRIPTION
It seems like this was basically `::all`, as described in https://github.com/rails/rails/issues/12756.

I tried to add tests for the rake task, but Parallel interferes with mocks.